### PR TITLE
Fixed regex

### DIFF
--- a/hulk.py
+++ b/hulk.py
@@ -146,7 +146,7 @@ else:
 		url = sys.argv[1]
 		if url.count("/")==2:
 			url = url + "/"
-		m = re.search('http?s\://([^/]*)/?.*', url)
+		m = re.search('https?\://([^/]*)/?.*', url)
 		host = m.group(1)
 		for i in range(500):
 			t = HTTPThread()

--- a/hulk.py
+++ b/hulk.py
@@ -146,8 +146,8 @@ else:
 		url = sys.argv[1]
 		if url.count("/")==2:
 			url = url + "/"
-		m = re.search('https?\://([^/]*)/?.*', url)
-		host = m.group(1)
+		m = re.search('(https?\://)?([^/]*)/?.*', url)
+		host = m.group(2)
 		for i in range(500):
 			t = HTTPThread()
 			t.start()


### PR DESCRIPTION
Old regex is not catching 'http' urls. It's only catching 'https'. New fix should catch both.
